### PR TITLE
README.rst: mention "jedi:install-imenu"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,5 +21,5 @@ Example to open the viewer by `C-c x` in Python buffer::
 Requirements
 ============
 
-- `jedi.el <http://tkf.github.io/emacs-jedi/>`_
+- `jedi.el <http://tkf.github.io/emacs-jedi/>`_ (``jedi:install-imenu`` should be non-nil)
 - `direx.el <https://github.com/m2ym/direx-el>`_


### PR DESCRIPTION
It's never stated that non-nil `jedi:install-imenu` is necessary for `jedi-direx` to operate and it took about an hour to find out why did it fail on my installation.
