### PR TITLE
Fix import hiding

### DIFF
--- a/jedi-direx.el
+++ b/jedi-direx.el
@@ -72,7 +72,7 @@
   (delq nil
         (mapcar
          (lambda (item)
-           (let ((item-type (plist-get (car item) :item-type)))
+           (let ((item-type (plist-get (car item) :type)))
              (unless (and jedi-direx:hide-imports
                           (stringp item-type) (string= item-type "import"))
                item)))


### PR DESCRIPTION
I've introduced a typo when refactoring (as reported in #12) and never noticed because I was still using unrefactored code.

This should fix that.
