### PR TITLE
Require jedi-core instead of full jedi

### DIFF
--- a/jedi-direx.el
+++ b/jedi-direx.el
@@ -28,7 +28,7 @@
 
 ;;; Code:
 
-(require 'jedi)
+(require 'jedi-core)
 (require 'direx)
 
 


### PR DESCRIPTION
This will allow jedi-direx to be used by company-mode users, who can't install the full version of jedi.
